### PR TITLE
fix: split path on win32

### DIFF
--- a/packages/plugin-core/src/index.ts
+++ b/packages/plugin-core/src/index.ts
@@ -56,7 +56,7 @@ export default (api) => {
       const excludes = runtimeModules.map(modulePath => {
         // add default node_modules
         if (modulePath.includes('node_modules')) {
-          return process.platform === 'win32' ? modulePath.replace(/\\/g, '\\\\') : modulePath;
+          return process.platform === 'win32' ? modulePath.split(path.sep).join('/') : modulePath;
         }
         return false;
 


### PR DESCRIPTION
## 修复

- https://github.com/ice-lab/icejs/issues/43

![image](https://user-images.githubusercontent.com/3995814/75015266-2a1b2780-54c3-11ea-8159-a94afa04bc47.png)
