### PR TITLE
feat: use ice lazy out of routes file

### DIFF
--- a/examples/basic-spa/src/pages/About/components/Child.tsx
+++ b/examples/basic-spa/src/pages/About/components/Child.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Child = () => {
+  return (
+    <div>
+      Child
+    </div>
+  );
+};
+
+export default Child;

--- a/examples/basic-spa/src/pages/About/index.tsx
+++ b/examples/basic-spa/src/pages/About/index.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import { Link } from 'ice';
+import { Link, lazy } from 'ice';
 
-const Child = () => {
-  return (
-    <div>
-      Child
-    </div>
-  );
-};
+const Child = lazy(() => import('./components/Child'));
 
 const About = () => {
   return (

--- a/packages/plugin-core/src/generator/templates/app/index.ts.ejs
+++ b/packages/plugin-core/src/generator/templates/app/index.ts.ejs
@@ -1,3 +1,4 @@
+import * as React from 'react';
 <%- iceImports %>
 
 export * from './components';
@@ -6,11 +7,15 @@ export * from './types';
 
 export const APP_MODE = (typeof window !== 'undefined' && window.__app_mode__) || process.env.APP_MODE;
 
-export function lazy(dynamicImport) {
-  return {
-    '__LAZY__': true,
-    dynamicImport
-  };
+export function lazy(dynamicImport, isRouteComponent?: Boolean): any {
+  if (isRouteComponent) {
+    return {
+      __LAZY__: true,
+      dynamicImport,
+    };
+  } else {
+    return React.lazy(dynamicImport);
+  }
 }
 
 <% if (iceExports) { %>

--- a/packages/plugin-core/src/generator/templates/app/index.ts.ejs
+++ b/packages/plugin-core/src/generator/templates/app/index.ts.ejs
@@ -1,22 +1,11 @@
-import * as React from 'react';
 <%- iceImports %>
 
 export * from './components';
 export * from './createApp';
 export * from './types';
+export * from './lazy';
 
 export const APP_MODE = (typeof window !== 'undefined' && window.__app_mode__) || process.env.APP_MODE;
-
-export function lazy(dynamicImport, isRouteComponent?: Boolean): any {
-  if (isRouteComponent) {
-    return {
-      __LAZY__: true,
-      dynamicImport,
-    };
-  } else {
-    return React.lazy(dynamicImport);
-  }
-}
 
 <% if (iceExports) { %>
 export {

--- a/packages/plugin-core/src/generator/templates/app/lazy.ts.ejs
+++ b/packages/plugin-core/src/generator/templates/app/lazy.ts.ejs
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+function lazy(dynamicImport, isRouteComponent?: Boolean): any {
+  if (isRouteComponent) {
+    return {
+      __LAZY__: true,
+      dynamicImport,
+    };
+  } else {
+    return React.lazy(dynamicImport);
+  }
+}
+
+
+export { lazy };

--- a/packages/plugin-router/src/babelPluginLazy.ts
+++ b/packages/plugin-router/src/babelPluginLazy.ts
@@ -1,0 +1,45 @@
+// eslint-disable-next-line no-unused-vars
+module.exports = ({ types }, { routeFile }) => {
+  let hasLazyImport = false;
+  let importName = '';
+  return {
+    visitor: {
+      ImportDeclaration(nodePath, state) {
+        // only transform route files
+        const isRouteConfig = routeFile === state.filename;
+        if (isRouteConfig) {
+          const { node } = nodePath;
+          if (types.isStringLiteral(node.source, { value: 'ice'})) {
+            node.specifiers.forEach((importSpecifier) => {
+              if (importSpecifier.imported && types.isIdentifier(importSpecifier.imported, { name: 'lazy'})) {
+                hasLazyImport = true;
+              }
+              if (types.isImportNamespaceSpecifier(importSpecifier)) {
+                // ice has no default export, just check ImportNamespaceSpecifier
+                importName = importSpecifier.local && importSpecifier.local.name;
+              }
+            });
+          }
+        }
+      },
+      CallExpression(nodePath, state) {
+        // only transform route files
+        const isRouteConfig = routeFile === state.filename;
+        if (isRouteConfig) {
+          const { node } = nodePath;
+          if (
+            // case import * as xxx from 'ice'; xxx.lazy
+            (importName && types.isMemberExpression(node.callee)
+              && types.isIdentifier(node.callee.object, { name: importName})
+              && types.isIdentifier(node.callee.property, { name: 'lazy'})) ||
+            // case import { lazy } from 'ice';
+            (hasLazyImport && types.isIdentifier(node.callee, { name: 'lazy' }))) {
+            if (node.arguments.length === 1) {
+              node.arguments.push(types.booleanLiteral(true));
+            }
+          }
+        }
+      },
+    },
+  };
+};


### PR DESCRIPTION
#108 
使用上在非路由文件中使用 React.lazy 和 ice 导出的 lazy 均可以，建议统一从 ice 中导出