### PR TITLE
fix: get __app_mode__ from global

### DIFF
--- a/packages/plugin-config/config/index.ts
+++ b/packages/plugin-config/config/index.ts
@@ -6,7 +6,8 @@ interface Config {
 
 const userConfig: Config = {
   ...(config.default || {}),
-  ...(config[((typeof window !== 'undefined') && window.__app_mode__) || process.env.APP_MODE] || {}),
+  // webpack will automatically convert global to window when target is web
+  ...(config[(global as any).__app_mode__ || process.env.APP_MODE] || {}),
 };
 
 export default userConfig;

--- a/packages/plugin-core/src/generator/templates/app/index.ts.ejs
+++ b/packages/plugin-core/src/generator/templates/app/index.ts.ejs
@@ -4,7 +4,7 @@ export * from './components';
 export * from './createApp';
 export * from './types';
 
-export const APP_MODE = (typeof window !== 'undefined' && window.__app_mode__) || process.env.APP_MODE;
+export const APP_MODE = (global as any).__app_mode__ || process.env.APP_MODE;
 
 export function lazy(dynamicImport) {
   return {


### PR DESCRIPTION
CSR: `window.__app_mode__ = 'prod';`
SSR:` global.__app_mode = 'prod';` // compatible with CSR