### PR TITLE
fix: debug port for start child process

### DIFF
--- a/packages/icejs/bin/start.js
+++ b/packages/icejs/bin/start.js
@@ -11,7 +11,7 @@ const rawArgv = parse(process.argv.slice(2));
 const scriptPath = require.resolve('./child-process-start.js');
 const configPath = path.resolve(rawArgv.config || 'build.json');
 
-const inspectRegExp = /^--(inspect(?:-brk)?)(?:=(?:[^:]+:)?(\d+))?$/;
+const inspectRegExp = /^--(inspect(?:-brk)?)(?:=(?:([^:]+):)?(\d+))?$/;
 
 function modifyInspectArgv(argv) {
   return Promise.all(
@@ -24,7 +24,7 @@ function modifyInspectArgv(argv) {
       const [_, command, ip, port = 9229] = matchResult;
       const nPort = +port;
       const newPort = await detect(nPort);
-      return `--${command}=${ip || ''}${newPort}`;
+      return `--${command}=${ip ? `${ip}:` : ''}${newPort}`;
     })
   );
 }


### PR DESCRIPTION
when we run the `icejs start` command in debug mode,  it generated a invalid debug port for `start` child process.
### Detail
the debug argument regex in file [bin/start.js](https://github.com/ice-lab/icejs/blob/master/packages/icejs/bin/start.js#L14) is:
```js
/^--(inspect(?:-brk)?)(?:=(?:[^:]+:)?(\d+))?$/
```
the `ip` match group was ignored. `matchResult[2]` is the port value, but read as `ip`,  `matchResult[3]` is `undefined`, but read as `port`.
for example, the original argument is `--inspect-brk=127.0.0.1:1234`, run to the breakpoint, the `ip` is equals to `1234`, the `port` is equals to `undefined`, so new port was detected, e.g. `8765`, as a result, we got a new argument with a invalid port value `--inspect-brk=12348765`. ❌

![image](https://user-images.githubusercontent.com/5102113/79352276-34f6b380-7f6c-11ea-937c-0f0f0f41d20f.png)

### Solution 
the regex is changed to:
```
/^--(inspect(?:-brk)?)(?:=(?:([^:]+):)?(\d+))?$/
```
as indicated above, run to the breakpoint,  the `ip` is equals to `127.0.0.1`, the `port` is equals to `1234`, beacause port `1234` is used by parent process, a new port was detected, e.g. `1235`, as a result, we got a new argument with a valid port value `--inspect-brk=1235`. ✅

![image](https://user-images.githubusercontent.com/5102113/79348502-a718c980-7f67-11ea-8077-9c5488d112b7.png)

test cases:
```js
const reg = /^--(inspect(?:-brk)?)(?:=(?:([^:]+):)?(\d+))?$/;
[ '--inspect-brk=127.0.0.1:1234', '--inspect-brk=localhost:1234', '--inspect-brk=1234' ].forEach(arg => {
  console.log(reg.exec(arg));
});
```
test results:
![image](https://user-images.githubusercontent.com/5102113/79353613-dc281a80-7f6d-11ea-82f1-de061f292644.png)

