### PR TITLE
feat: require plugin with [require.resolve]

### DIFF
--- a/packages/icejs/src/index.ts
+++ b/packages/icejs/src/index.ts
@@ -1,22 +1,22 @@
 const getBuiltInPlugins = (userConfig) => {
   // built-in plugins for icejs
   const builtInPlugins = [
-    'build-plugin-ice-core',
-    'build-plugin-react-app',
-    'build-plugin-ice-router',
-    'build-plugin-ice-helpers',
-    'build-plugin-ice-logger',
-    'build-plugin-ice-config',
-    'build-plugin-ice-request',
-    'build-plugin-ice-mpa'
+    require.resolve('build-plugin-ice-core'),
+    require.resolve('build-plugin-react-app'),
+    require.resolve('build-plugin-ice-router'),
+    require.resolve('build-plugin-ice-helpers'),
+    require.resolve('build-plugin-ice-logger'),
+    require.resolve('build-plugin-ice-config'),
+    require.resolve('build-plugin-ice-request'),
+    require.resolve('build-plugin-ice-mpa')
   ];
 
   if (userConfig.ssr) {
-    builtInPlugins.push('build-plugin-ice-ssr');
+    builtInPlugins.push(require.resolve('build-plugin-ice-ssr'));
   }
 
   if (!Object.prototype.hasOwnProperty.call(userConfig, 'store') || userConfig.store !== false) {
-    builtInPlugins.push('build-plugin-ice-store');
+    builtInPlugins.push(require.resolve('build-plugin-ice-store'));
   }
 
   return builtInPlugins;


### PR DESCRIPTION
场景： 
ice.js作为全局命令安装(`npm i ice.js -g`)
在项目路径下执行`icejs build` （注意： icejs不在项目路径下安装)

问题：
抛出错误：`ERR! Cannot find module 'build-plugin-ice-core'`
![image](https://user-images.githubusercontent.com/24466804/81245481-a5629300-9047-11ea-8f36-105c289c5bc7.png)

原因：
@ali/build-scripts/lib/core/Context.ts文件
resolvePlugins方法中`const pluginPath = require.resolve(plugins[0], { paths: [this.rootDir] });`将paths设置成了当前目录，因此内置插件找不到依赖包

解决方案：
插件的引用跟着icejs的目录走